### PR TITLE
[MJLINK-6] Add 'sourceJdkModules' configuration parameter.

### DIFF
--- a/src/it/projects/MJLINK-6_allowSetJmodPath/invoker.properties
+++ b/src/it/projects/MJLINK-6_allowSetJmodPath/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+invoker.java.version = 1.9+
+invoker.goals = clean package

--- a/src/it/projects/MJLINK-6_allowSetJmodPath/pom.xml
+++ b/src/it/projects/MJLINK-6_allowSetJmodPath/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
+>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-jlink-plugin-mjlink-6</artifactId>
+  <version>96.0</version>
+  <packaging>jlink</packaging>
+  <url>https://issues.apache.org/jira/browse/MJLINK-6</url>
+
+  <description>Test JLink create a distributable JVM that is not currently used</description>
+  <properties>
+    <maven.compiler.source>1.9</maven.compiler.source>
+    <maven.compiler.target>1.9</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+        <configuration>
+          <source>1.9</source>
+          <target>1.9</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jlink-plugin</artifactId>
+        <version>@project.version@</version>
+        <extensions>true</extensions>
+        <configuration>
+          <sourceJdkModules>${java.home}</sourceJdkModules>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/MJLINK-6_allowSetJmodPath/src/main/java/com/corporate/project/Main.java
+++ b/src/it/projects/MJLINK-6_allowSetJmodPath/src/main/java/com/corporate/project/Main.java
@@ -1,0 +1,35 @@
+package com.corporate.project;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Main
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Main one from Java 9+" );
+        if ( args.length > 0 )
+        {
+            for ( String arg : args )
+            {
+                System.out.println( " Arg: '" + arg + "'" );
+            }
+        }
+    }
+}

--- a/src/it/projects/MJLINK-6_allowSetJmodPath/src/main/java/module-info.java
+++ b/src/it/projects/MJLINK-6_allowSetJmodPath/src/main/java/module-info.java
@@ -1,0 +1,24 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module com.corporate.project {
+  requires java.base;
+  exports com.corporate.project;
+}

--- a/src/it/projects/MJLINK-6_allowSetJmodPath/verify.groovy
+++ b/src/it/projects/MJLINK-6_allowSetJmodPath/verify.groovy
@@ -1,0 +1,30 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*
+import java.util.*
+import java.util.jar.*
+import org.codehaus.plexus.util.*
+
+File target = new File( basedir, "target" );
+assert target.isDirectory()
+
+File artifact = new File( target, "maven-jlink-plugin-mjlink-6-96.0.zip" );
+assert artifact.isFile()

--- a/src/main/java/org/apache/maven/plugins/jlink/JLinkMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jlink/JLinkMojo.java
@@ -241,6 +241,12 @@ public class JLinkMojo
     private ZipArchiver zipArchiver;
 
     /**
+     * Set the JDK location to create a Java custom runtime image.
+     */
+    @Parameter
+    private File sourceJdkModules;
+
+    /**
      * Name of the generated ZIP file in the <code>target</code> directory. This will not change the name of the
      * installed/deployed file.
      */
@@ -260,7 +266,15 @@ public class JLinkMojo
 
         // Really Hacky...do we have a better solution to find the jmods directory of the JDK?
         File jLinkParent = jLinkExecuteable.getParentFile().getParentFile();
-        File jmodsFolder = new File( jLinkParent, JMODS );
+        File jmodsFolder;
+        if ( sourceJdkModules != null && sourceJdkModules.isDirectory() )
+        {
+            jmodsFolder = new File ( sourceJdkModules, JMODS );
+        }
+        else
+        {
+            jmodsFolder = new File( jLinkParent, JMODS );
+        }
 
         getLog().debug( " Parent: " + jLinkParent.getAbsolutePath() );
         getLog().debug( " jmodsFolder: " + jmodsFolder.getAbsolutePath() );


### PR DESCRIPTION
This parameter allows to create a distributable Java custom runtime image without relying on JAVA_HOME/Toolschain. This allows to create a Java custom runtime image from one Operating System to another.

I cannot rely on JAVA_HOME and Toolchain location because this JDK have to be able to run where the build will be run. This is not the case when I want to generate a Java custom runtime image for Windows, building the project in a Linux host, for example.

PS: It is not clear where JDK for this issue's test will be located.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MJLINK) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MJLINK-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MJLINK-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [X] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

