### PR TITLE
(build) Add Java8 + Toolchain tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,6 +42,32 @@ jobs:
           restore-keys: |
             maven-${{ matrix.os }}-java${{ matrix.java }}-
             maven-${{ matrix.os }}-
+      - name: Install Toolchain JDK
+        if: ${{ matrix.java == '8' }}
+        uses: battila7/jdk-via-jabba@v1
+        with:
+          jdk: adopt-openj9@1.11.0-7
+          javaHomeEnvironmentVariable: TOOLCHAIN_JDK
+      - name: Set up Toolchain
+        if: ${{ matrix.java == '8' }}
+        shell: bash
+        run: |
+          mkdir -p $HOME/.m2 \
+          && cat << EOF > $HOME/.m2/toolchains.xml
+          <?xml version="1.0" encoding="UTF8"?>
+          <toolchains>
+            <toolchain>
+              <type>jdk</type>
+                <provides>
+                  <version>11</version>
+                  <vendor>adopt</vendor>
+                </provides>
+                <configuration>
+                  <jdkHome>${{ env.TOOLCHAIN_JDK }}</jdkHome>
+                </configuration>
+            </toolchain>
+          </toolchains>
+          EOF
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
@@ -49,3 +75,4 @@ jobs:
 
       - name: Build with Maven
         run: mvn verify -e -B -V -Prun-its
+

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,3 @@ out/
 /bootstrap
 /dependencies.xml
 .java-version
-# for testing
-it-toolchains.xml

--- a/src/it/projects/MJLINK-36_toolchainjdk8/verify.groovy
+++ b/src/it/projects/MJLINK-36_toolchainjdk8/verify.groovy
@@ -1,0 +1,32 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*
+import java.util.*
+import java.util.jar.*
+import org.codehaus.plexus.util.*
+
+File target = new File( basedir, "target" )
+assert target.isDirectory()
+
+File jarArtifact = new File( target, "mjlink36-toolchain-jdk8-1.0.0-SNAPSHOT.zip" )
+assert jarArtifact.isFile()
+
+// optional: check if it contains a launcher script

--- a/src/it/projects/MJLINK-36_toolchainjdk9/verify.groovy
+++ b/src/it/projects/MJLINK-36_toolchainjdk9/verify.groovy
@@ -1,0 +1,32 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*
+import java.util.*
+import java.util.jar.*
+import org.codehaus.plexus.util.*
+
+File target = new File( basedir, "target" )
+assert target.isDirectory()
+
+File jarArtifact = new File( target, "mjlink36-toolchain-jdk9-1.0.0-SNAPSHOT.zip" )
+assert jarArtifact.isFile()
+
+// optional: check if it contains a launcher script


### PR DESCRIPTION
This PR adds a `toolchain.xml` file to `$HOME/.m2` if the build was run using a JDK 8.
The toolchain is being initialized with a Jabba-provided OpenJ9 Java 11 JDK.

This way, we can test the plugin execution when Java 8 is being used to run maven and the JDK11 will be used as a toolchain JDK für the corresponding IT.

Up to now, we did not have a test which tested the JDK8+toolchain path.

--- 

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MJLINK) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[MJLINK-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MJLINK-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [X] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [X] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

