### PR TITLE
[MJLINK-52] Add classifier support

### DIFF
--- a/src/it/projects/MJLINK-52_classifiers/invoker.properties
+++ b/src/it/projects/MJLINK-52_classifiers/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+invoker.java.version = 1.9+
+invoker.goals = clean package

--- a/src/it/projects/MJLINK-52_classifiers/pom.xml
+++ b/src/it/projects/MJLINK-52_classifiers/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
+>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-jlink-plugin-mjlink-52</artifactId>
+  <version>96.0</version>
+  <packaging>jlink</packaging>
+  <name>Maven</name>
+  <url>https://maven.apache.org</url>
+  <description>Test JLink creates archives with classifiers.</description>
+  <properties>
+    <maven.compiler.release>9</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jlink-plugin</artifactId>
+        <version>@project.version@</version>
+        <extensions>true</extensions>
+        <configuration>
+          <classifier>jlink</classifier>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/MJLINK-52_classifiers/src/main/java/com/corporate/project/Main.java
+++ b/src/it/projects/MJLINK-52_classifiers/src/main/java/com/corporate/project/Main.java
@@ -1,0 +1,35 @@
+package com.corporate.project;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Main
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Main one from Java 9+" );
+        if ( args.length > 0 )
+        {
+            for ( String arg : args )
+            {
+                System.out.println( " Arg: '" + arg + "'" );
+            }
+        }
+    }
+}

--- a/src/it/projects/MJLINK-52_classifiers/src/main/java/module-info.java
+++ b/src/it/projects/MJLINK-52_classifiers/src/main/java/module-info.java
@@ -1,0 +1,24 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module com.corporate.project {
+  requires java.base;
+  exports com.corporate.project;
+}

--- a/src/it/projects/MJLINK-52_classifiers/verify.groovy
+++ b/src/it/projects/MJLINK-52_classifiers/verify.groovy
@@ -1,0 +1,48 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+import java.util.*;
+import java.util.jar.*;
+import org.codehaus.plexus.util.*;
+
+try
+{
+    File target = new File( basedir, "target" )
+    if ( !target.exists() || !target.isDirectory() )
+    {
+        System.err.println( "target file is missing or not a directory." )
+        return false
+    }
+
+    File artifact = new File( target, "maven-jlink-plugin-mjlink-52-96.0-jlink.zip" )
+    if ( !artifact.exists() || artifact.isDirectory() )
+    {
+        System.err.println( "maven-jlink-plugin-mjlink-52-96.0-jlink.zip file is missing or is a directory." )
+        return false
+    }
+
+    return true
+}
+catch( Throwable e )
+{
+    e.printStackTrace()
+    return false
+}

--- a/src/it/projects/MJLINK-52_classifiers_duplicate_classifier/invoker.properties
+++ b/src/it/projects/MJLINK-52_classifiers_duplicate_classifier/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+invoker.java.version = 1.9+
+invoker.goals = clean package

--- a/src/it/projects/MJLINK-52_classifiers_duplicate_classifier/pom.xml
+++ b/src/it/projects/MJLINK-52_classifiers_duplicate_classifier/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
+>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-jlink-plugin-mjlink-52</artifactId>
+  <version>96.0</version>
+  <packaging>jar</packaging>
+  <name>Maven</name>
+  <url>https://maven.apache.org</url>
+  <description>Test JLink does not fail on duplicate classifiers.</description>
+  <properties>
+    <maven.compiler.release>9</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jlink-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>primary-jlink</id>
+            <goals>
+              <goal>jlink</goal>
+            </goals>
+            <configuration>
+              <classifier>jlink1</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>secondary-jlink</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jlink</goal>
+            </goals>
+            <configuration>
+              <classifier>jlink1</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/MJLINK-52_classifiers_duplicate_classifier/src/main/java/com/corporate/project/Main.java
+++ b/src/it/projects/MJLINK-52_classifiers_duplicate_classifier/src/main/java/com/corporate/project/Main.java
@@ -1,0 +1,35 @@
+package com.corporate.project;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Main
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Main one from Java 9+" );
+        if ( args.length > 0 )
+        {
+            for ( String arg : args )
+            {
+                System.out.println( " Arg: '" + arg + "'" );
+            }
+        }
+    }
+}

--- a/src/it/projects/MJLINK-52_classifiers_duplicate_classifier/src/main/java/module-info.java
+++ b/src/it/projects/MJLINK-52_classifiers_duplicate_classifier/src/main/java/module-info.java
@@ -1,0 +1,24 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module com.corporate.project {
+  requires java.base;
+  exports com.corporate.project;
+}

--- a/src/it/projects/MJLINK-52_classifiers_duplicate_classifier/verify.groovy
+++ b/src/it/projects/MJLINK-52_classifiers_duplicate_classifier/verify.groovy
@@ -1,0 +1,47 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+import java.util.*;
+import java.util.jar.*;
+import org.codehaus.plexus.util.*;
+
+try
+{
+    File target = new File( basedir, "target" );
+    if ( !target.exists() || !target.isDirectory() )
+    {
+        System.err.println( "target file is missing or not a directory." );
+        return false;
+    }
+    File artifact = new File( target, "maven-jlink-plugin-mjlink-52-96.0-jlink1.zip" );
+    if ( !artifact.exists() || artifact.isDirectory() )
+    {
+        System.err.println( "maven-jlink-plugin-mjlink-52-96.0-jlink1.zip file is missing or is a directory." );
+        return false;
+    }
+
+    return true;
+}
+catch( Throwable e )
+{
+    e.printStackTrace();
+    return false;
+}

--- a/src/it/projects/MJLINK-52_classifiers_duplicate_default/invoker.properties
+++ b/src/it/projects/MJLINK-52_classifiers_duplicate_default/invoker.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+invoker.java.version = 1.9+
+invoker.goals = clean package
+invoker.buildResult = failure

--- a/src/it/projects/MJLINK-52_classifiers_duplicate_default/pom.xml
+++ b/src/it/projects/MJLINK-52_classifiers_duplicate_default/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
+>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-jlink-plugin-mjlink-52</artifactId>
+  <version>96.0</version>
+  <packaging>jlink</packaging>
+  <name>Maven</name>
+  <url>https://maven.apache.org</url>
+  <description>Test JLink fails on duplicate default artifact.</description>
+  <properties>
+    <maven.compiler.release>9</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jlink-plugin</artifactId>
+        <version>@project.version@</version>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>default-jlink</id>
+          </execution>
+          <execution>
+            <!-- this execution must fail because a default artifact may not be attached twice. -->
+            <id>secondary-jlink</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jlink</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/MJLINK-52_classifiers_duplicate_default/src/main/java/com/corporate/project/Main.java
+++ b/src/it/projects/MJLINK-52_classifiers_duplicate_default/src/main/java/com/corporate/project/Main.java
@@ -1,0 +1,35 @@
+package com.corporate.project;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Main
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Main one from Java 9+" );
+        if ( args.length > 0 )
+        {
+            for ( String arg : args )
+            {
+                System.out.println( " Arg: '" + arg + "'" );
+            }
+        }
+    }
+}

--- a/src/it/projects/MJLINK-52_classifiers_duplicate_default/src/main/java/module-info.java
+++ b/src/it/projects/MJLINK-52_classifiers_duplicate_default/src/main/java/module-info.java
@@ -1,0 +1,24 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module com.corporate.project {
+  requires java.base;
+  exports com.corporate.project;
+}

--- a/src/it/projects/MJLINK-52_classifiers_duplicate_default/verify.groovy
+++ b/src/it/projects/MJLINK-52_classifiers_duplicate_default/verify.groovy
@@ -1,0 +1,47 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+import java.util.*;
+import java.util.jar.*;
+import org.codehaus.plexus.util.*;
+
+try
+{
+    File target = new File( basedir, "target" );
+    if ( !target.exists() || !target.isDirectory() )
+    {
+        System.err.println( "target file is missing or not a directory." );
+        return false;
+    }
+    File artifact = new File( target, "maven-jlink-plugin-mjlink-52-96.0.zip" );
+    if ( !artifact.exists() || artifact.isDirectory() )
+    {
+        System.err.println( "maven-jlink-plugin-mjlink-52-96.0.zip file is missing or is a directory." );
+        return false;
+    }
+
+    return true;
+}
+catch( Throwable e )
+{
+    e.printStackTrace();
+    return false;
+}

--- a/src/it/projects/MJLINK-52_classifiers_jarproject/invoker.properties
+++ b/src/it/projects/MJLINK-52_classifiers_jarproject/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+invoker.java.version = 1.9+
+invoker.goals = clean package

--- a/src/it/projects/MJLINK-52_classifiers_jarproject/pom.xml
+++ b/src/it/projects/MJLINK-52_classifiers_jarproject/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
+>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-jlink-plugin-mjlink-52</artifactId>
+  <version>96.0</version>
+  <packaging>jar</packaging>
+  <name>Maven</name>
+  <url>https://maven.apache.org</url>
+  <description>Test JLink creates an additional archive with classifiers on a jar-packaged project.</description>
+  <properties>
+    <maven.compiler.release>9</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jlink-plugin</artifactId>
+        <version>@project.version@</version>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>create-dist</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jlink</goal>
+            </goals>
+            <configuration>
+              <classifier>jlink</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/MJLINK-52_classifiers_jarproject/src/main/java/com/corporate/project/Main.java
+++ b/src/it/projects/MJLINK-52_classifiers_jarproject/src/main/java/com/corporate/project/Main.java
@@ -1,0 +1,35 @@
+package com.corporate.project;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Main
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Main one from Java 9+" );
+        if ( args.length > 0 )
+        {
+            for ( String arg : args )
+            {
+                System.out.println( " Arg: '" + arg + "'" );
+            }
+        }
+    }
+}

--- a/src/it/projects/MJLINK-52_classifiers_jarproject/src/main/java/module-info.java
+++ b/src/it/projects/MJLINK-52_classifiers_jarproject/src/main/java/module-info.java
@@ -1,0 +1,24 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module com.corporate.project {
+  requires java.base;
+  exports com.corporate.project;
+}

--- a/src/it/projects/MJLINK-52_classifiers_jarproject/verify.groovy
+++ b/src/it/projects/MJLINK-52_classifiers_jarproject/verify.groovy
@@ -1,0 +1,55 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+import java.util.*;
+import java.util.jar.*;
+import org.codehaus.plexus.util.*;
+
+try
+{
+    File target = new File( basedir, "target" )
+    if ( !target.exists() || !target.isDirectory() )
+    {
+        System.err.println( "target file is missing or not a directory." )
+        return false
+    }
+
+    File primaryArtifact = new File( target, "maven-jlink-plugin-mjlink-52-96.0.jar" )
+    if ( !primaryArtifact.exists() || primaryArtifact.isDirectory() )
+    {
+        System.err.println( "maven-jlink-plugin-mjlink-52-96.0.jar file is missing or is a directory." )
+        return false
+    }
+
+    File jlinkArtifact = new File( target, "maven-jlink-plugin-mjlink-52-96.0-jlink.zip" )
+    if ( !jlinkArtifact.exists() || jlinkArtifact.isDirectory() )
+    {
+        System.err.println( "maven-jlink-plugin-mjlink-52-96.0-jlink.zip file is missing or is a directory." )
+        return false
+    }
+
+    return true
+}
+catch( Throwable e )
+{
+    e.printStackTrace()
+    return false
+}

--- a/src/main/java/org/apache/maven/plugins/jlink/AbstractJLinkMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jlink/AbstractJLinkMojo.java
@@ -59,6 +59,12 @@ public abstract class AbstractJLinkMojo
     @Component
     private ToolchainManager toolchainManager;
 
+    /**
+     * Overload this to produce a zip with another classifier, for example a jlink-zip.
+     * @return get the classifier.
+     */
+    protected abstract String getClassifier();
+
     protected JLinkExecutor getJlinkExecutor()
     {
         return new JLinkExecutor( getToolchain().orElse( null ), getLog() );
@@ -167,7 +173,7 @@ public abstract class AbstractJLinkMojo
     protected boolean hasClassifier( String classifier )
     {
         boolean result = false;
-        if ( classifier != null && classifier.trim().length() > 0 )
+        if ( classifier != null && !classifier.isEmpty() )
         {
             result = true;
         }


### PR DESCRIPTION
This PR will add classifier support to the `maven-jlink-plugin`,  similar how the `maven-jar-plugin` uses qualifiers.

Changes:

* Add a qualifier parameter.
* The `imageDirectoryOutput` parameter stays readonly, but will be changed according to the classifier. The method is `setOutputDirectoryImage()`. 
    This will ensure that all the "sources" for the zip archive will be inspectable after the build and/or can be run by the user without extracting the archive. The `TODO` comment was therefore removed.
  * If no classifier is given, `{$outputdir}/target/maven-jlink/default}` will be used.
  * If classifier is given, the directory `{$outputdir}/target/maven-jlink/classifiers/$classifier}` will be used.
  
* The logic for throwing an execption for primary artifacts ("You have to use a classifier…") was changed to the behaviour of the `maven-jar-plugin`.
* Added ITs:
  * `MJLINK-52_classifiers` -  build a jlink project, but do not attach a primary artifact – use the classifier.
  * `MJLINK-52_classifiers_jarproject` – build a jar project, add a jlink execution with classifier (will pass)
  * (not realized) build a jar project, add a jlink execution without classifier (will fail as before, omnited for next one).
  * `MJLINK-52_classifiers_duplicate_default` – build a jlink project, add a jlink execution without classifier (will fail – same as above).
  * `MJLINK-52_classifiers_duplicate_classifier` – build a jar project, add two jlink executions using the same classifier. No error or warning will be printed, the last overwrites (will pass, same as with the `maven-jar-plugin`).

---

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MJLINK) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MJLINK-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MJLINK-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [X] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [X] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

