### PR TITLE
[MJLINK-64] Fix addOptions arguments passing

### DIFF
--- a/src/it/projects/cli-options/add-options/verify.groovy
+++ b/src/it/projects/cli-options/add-options/verify.groovy
@@ -25,7 +25,7 @@ import org.codehaus.plexus.util.*
 
 String buildlog = new File( basedir, "build.log").text
 assert buildlog.contains( "--add-options" )
-assert buildlog.contains( "\"-Xmx128m --enable-preview -Dvar=value\"" )
+assert buildlog.contains( "-Xmx128m --enable-preview -Dvar=value" )
 
 File target = new File( basedir, "target" )
 assert target.isDirectory()

--- a/src/main/java/org/apache/maven/plugins/jlink/JLinkMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jlink/JLinkMojo.java
@@ -108,6 +108,8 @@ public class JLinkMojo
      *
      * <p>The command line equivalent is: {@code jlink --add-options="..."}.</p>
      *
+     * Spaces in options are not supported, they will be treated as separate options.
+     *
      * <p>Example:</p>
      *
      * <pre>
@@ -654,7 +656,7 @@ public class JLinkMojo
         if ( addOptions != null && !addOptions.isEmpty() )
         {
             jlinkArgs.add( "--add-options" );
-            jlinkArgs.add( String.format( "\"%s\"", String.join( " ", addOptions ) ) );
+            jlinkArgs.add( String.format( "%s", String.join( " ", addOptions ) ) );
         }
 
         if ( disablePlugin != null )


### PR DESCRIPTION
Remove double quotes from --add-options values. With double quotes it treats arguments like -Dprop1=val1 -Dprop2=val2 as a single arg, so in runtime it prop2 is null and prop1 is val1 -Dprop2=val2

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MJLINK) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MJLINK-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MJLINK-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

