### PR TITLE
[MJLINK-77] accept JDK21+ compress parameters

### DIFF
--- a/src/it/projects/MJLINK-77_compress-parameters/invoker.properties
+++ b/src/it/projects/MJLINK-77_compress-parameters/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+invoker.java.version = 21+
+invoker.goals = clean package

--- a/src/it/projects/MJLINK-77_compress-parameters/pom.xml
+++ b/src/it/projects/MJLINK-77_compress-parameters/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
+>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-jlink-plugin-mjlink-77</artifactId>
+  <version>96.0</version>
+  <packaging>jlink</packaging>
+  <name>Maven</name>
+  <url>https://maven.apache.org</url>
+  <description>Test JLink JDK21+ compress parameter.</description>
+  <properties>
+    <maven.compiler.release>21</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.12.0</version>
+        <configuration>
+          <release>21</release>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jlink-plugin</artifactId>
+        <version>@project.version@</version>
+        <extensions>true</extensions>
+        <configuration>
+          <compress>zip-1</compress>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/MJLINK-77_compress-parameters/src/main/java/com/corporate/project/Main.java
+++ b/src/it/projects/MJLINK-77_compress-parameters/src/main/java/com/corporate/project/Main.java
@@ -1,0 +1,35 @@
+package com.corporate.project;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Main
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Main one from Java 9+" );
+        if ( args.length > 0 )
+        {
+            for ( String arg : args )
+            {
+                System.out.println( " Arg: '" + arg + "'" );
+            }
+        }
+    }
+}

--- a/src/it/projects/MJLINK-77_compress-parameters/src/main/java/module-info.java
+++ b/src/it/projects/MJLINK-77_compress-parameters/src/main/java/module-info.java
@@ -1,0 +1,24 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module com.corporate.project {
+  requires java.base;
+  exports com.corporate.project;
+}

--- a/src/it/projects/MJLINK-77_compress-parameters/verify.groovy
+++ b/src/it/projects/MJLINK-77_compress-parameters/verify.groovy
@@ -1,0 +1,62 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+import java.util.*;
+import java.util.jar.*;
+import org.codehaus.plexus.util.*;
+
+boolean result = true;
+
+try
+{
+    File target = new File( basedir, "target" );
+    if ( !target.exists() || !target.isDirectory() )
+    {
+        System.err.println( "target file is missing or not a directory." );
+        return false;
+    }
+    File artifact = new File( target, "maven-jlink-plugin-mjlink-77-96.0.zip" );
+    if ( !artifact.exists() || artifact.isDirectory() )
+    {
+        System.err.println( "maven-jlink-plugin-mjlink-77-96.0.zip file is missing or is a directory." );
+        return false;
+    }
+
+    def buildLog = new File(basedir, "build.log")
+    def found = false
+    buildLog.eachLine{line ->
+        if (line.contains("--compress, zip-1")) {
+            found = true
+        }
+    }
+    if (!found) {
+        System.err.println( "Not found in build.log: '--compress, zip-1'." )
+        return false
+    }
+
+}
+catch( Throwable e )
+{
+    e.printStackTrace();
+    result = false;
+}
+
+return result;

--- a/src/test/java/org/apache/maven/plugins/jlink/JLinkMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jlink/JLinkMojoTest.java
@@ -21,7 +21,11 @@ package org.apache.maven.plugins.jlink;
 import java.lang.reflect.Field;
 import java.util.List;
 
+import org.apache.maven.plugin.MojoFailureException;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,5 +44,39 @@ public class JLinkMojoTest {
 
         // then
         assertThat(jlinkArgs).noneMatch(arg -> arg.trim().isBlank());
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+            value = {
+                "0,true",
+                "1,true",
+                "2,true",
+                "3,false",
+                "9,false",
+                // empty string is not valid.
+                "'',false",
+                // null is valid (i.e. not set).
+                ",true",
+                "zip,false",
+                "zip-0,true",
+                "zip-6,true",
+                "zip-9,true",
+                "zip-10,false",
+            })
+    void accepts_only_valid_compression_levels(String compress, boolean acceptable) {
+        try {
+            JLinkMojo.checkCompressParameter(compress);
+        } catch (MojoFailureException e) {
+            if (acceptable) {
+                Assertions.fail("Value [" + compress + "] should have been a valid value", e);
+            }
+
+            return;
+        }
+
+        if (!acceptable) {
+            Assertions.fail("Value [" + compress + "] should not have been a valid value");
+        }
     }
 }


### PR DESCRIPTION
This one needs a description. This PR changes the behaviour in a way that valid values will be checked according to the JDK 21 help. However, it would let values like `zip-6` pass for JDK < 21, which is not a valid value for JDK 9 through 20.

So, I was thinking, maybe not to check the parameters for validity at all OR extend the check. However, I would vote to drop the checks alltogether, because future jlink versions could accept `zstd-6` or `zst-6` as valid value, as well as other compression formats or number systems (like arabic). But since this would have been a change in behaviour AND easier to implement, I started with this version.

My -1, Let's get rid of the duplicate parameter checks. Just pass the user input to jlink.

---

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MJLINK) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MJLINK-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MJLINK-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [X] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [X] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

