### PR TITLE
[MJLINK-83] Implement multiple launcher elements

### DIFF
--- a/src/main/java/org/apache/maven/plugins/jlink/JLinkMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jlink/JLinkMojo.java
@@ -140,6 +140,17 @@ public class JLinkMojo extends AbstractJLinkMojo {
     private String launcher;
 
     /**
+     * Specify one or more launchers for jlink.
+     * The command line equivalent is:
+     * <code>--launcher &lt;name&gt;=&lt;module&gt;[/&lt;mainclass&gt;]</code>.
+     * The valid values are a list of
+     * <code>&lt;name&gt;=&lt;module&gt;[/&lt;mainclass&gt;]</code> terms,
+     * separated by commas.
+     */
+    @Parameter
+    private List<String> launchers;
+
+    /**
      * These JVM arguments will be appended to the {@code lib/modules} file.<br>
      * <strong>This parameter requires at least JDK 14.<br></strong>
      *
@@ -633,7 +644,8 @@ public class JLinkMojo extends AbstractJLinkMojo {
         }
     }
 
-    protected List<String> createJlinkArgs(Collection<String> pathsOfModules, Collection<String> modulesToAdd) {
+    protected List<String> createJlinkArgs(Collection<String> pathsOfModules, Collection<String> modulesToAdd)
+            throws MojoExecutionException {
         List<String> jlinkArgs = new ArrayList<>();
 
         if (stripDebug) {
@@ -656,8 +668,17 @@ public class JLinkMojo extends AbstractJLinkMojo {
             jlinkArgs.add(compress);
         }
         if (launcher != null) {
-            jlinkArgs.add("--launcher");
-            jlinkArgs.add(launcher);
+            if (launchers != null) {
+                throw new MojoExecutionException("Specify either single <launcher> or multiple <launchers>, not both.");
+            } else {
+                launchers = List.of(launcher);
+            }
+        }
+        if (launchers != null) {
+            for (String item : launchers) {
+                jlinkArgs.add("--launcher");
+                jlinkArgs.add(item);
+            }
         }
         if (addOptions != null && !addOptions.isEmpty()) {
             jlinkArgs.add("--add-options");

--- a/src/test/java/org/apache/maven/plugins/jlink/MultipleLauncherTest.java
+++ b/src/test/java/org/apache/maven/plugins/jlink/MultipleLauncherTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.jlink;
+
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class MultipleLauncherTest {
+    @Test
+    void testSingleLauncher() throws Exception {
+        // It's OK to specify one launcher with "<launcher>"
+        // given
+        JLinkMojo mojo = new JLinkMojo();
+        Field launcher = mojo.getClass().getDeclaredField("launcher");
+        launcher.setAccessible(true);
+        launcher.set(mojo, "l=com.example.Launch");
+
+        // when
+        List<String> jlinkArgs = mojo.createJlinkArgs(List.of(), List.of());
+
+        // then
+        assertThat(launched(jlinkArgs)).contains("l=com.example.Launch");
+    }
+
+    @Test
+    void testOneMultipleLauncher() throws Exception {
+        // It's OK to specify one launcher with "<launchers>"
+        // given
+        JLinkMojo mojo = new JLinkMojo();
+        Field launchers = mojo.getClass().getDeclaredField("launchers");
+        launchers.setAccessible(true);
+        launchers.set(mojo, List.of("l=com.example.Launch"));
+
+        // when
+        List<String> jlinkArgs = mojo.createJlinkArgs(List.of(), List.of());
+
+        // then
+        assertThat(launched(jlinkArgs)).contains("l=com.example.Launch");
+    }
+
+    @Test
+    void testMultipleLaunchers() throws Exception {
+        // It's OK to specify multiple launchers with the "<launchers>" element
+        // given
+        JLinkMojo mojo = new JLinkMojo();
+        Field launcher = mojo.getClass().getDeclaredField("launchers");
+        launcher.setAccessible(true);
+        launcher.set(mojo, List.of("l1=com.example.Launch1", "l2=com.example.Launch2"));
+
+        // when
+        List<String> jlinkArgs = mojo.createJlinkArgs(List.of(), List.of());
+
+        // then
+        assertThat(launched(jlinkArgs)).contains("l1=com.example.Launch1", "l2=com.example.Launch2");
+    }
+
+    @Test
+    void testInvalidLauncherConfig() throws Exception {
+        // It's an error to specify both "<launcher>" and "<launchers>"
+        // given
+        JLinkMojo mojo = new JLinkMojo();
+        Field launcher = mojo.getClass().getDeclaredField("launcher");
+        launcher.setAccessible(true);
+        launcher.set(mojo, "l3=com.example.Launch3");
+        Field launchers = mojo.getClass().getDeclaredField("launchers");
+        launchers.setAccessible(true);
+        launchers.set(mojo, List.of("l1=com.example.Launch1", "l2=com.example.Launch2"));
+
+        // When
+        assertThatThrownBy(() -> mojo.createJlinkArgs(List.of(), List.of())).isInstanceOf(MojoExecutionException.class);
+    }
+
+    // Helper function - gather all the classes named by --launcher args
+    private static Set<String> launched(List<String> args) {
+        Set<String> classNames = new HashSet<>();
+        Iterator<String> iterator = args.iterator();
+        while (iterator.hasNext()) {
+            String arg = iterator.next();
+            if ("--launcher".equals(arg)) {
+                if (iterator.hasNext()) {
+                    classNames.add(iterator.next());
+                } else {
+                    throw new IllegalStateException("--launcher arg with no classname");
+                }
+            }
+        }
+        return classNames;
+    }
+}


### PR DESCRIPTION
This is a simple change to allow the Maven plugin to generate more than one launcher in a `jlink` image. The `jlink` tool itself already supports this, but there was no way to pass the required invocation onto it from Maven.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [X] This [JIRA issue](https://issues.apache.org/jira/browse/MJLINK-83) has been filed for the change
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MJLINK-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MJLINK-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [X] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

