### PR TITLE
[MJLINK-88] separate Windows and Unix command line tests

### DIFF
--- a/src/test/java/org/apache/maven/plugins/jlink/JLinkMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jlink/JLinkMojoTest.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Field;
 import java.util.List;
 
 import org.apache.maven.shared.utils.cli.Commandline;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,6 +47,10 @@ public class JLinkMojoTest {
 
     @Test
     void single_quotes_shell_command() throws Exception {
+
+        Assumptions.assumeFalse("windows".equals(System.getProperty("os.name")));
+        // TODO add a test for Windows
+
         // given
         JLinkMojo mojo = new JLinkMojo();
         Field stripDebug = mojo.getClass().getDeclaredField("stripDebug");

--- a/src/test/java/org/apache/maven/plugins/jlink/JLinkMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jlink/JLinkMojoTest.java
@@ -26,6 +26,9 @@ import org.apache.maven.shared.utils.cli.Commandline;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -50,10 +53,9 @@ public class JLinkMojoTest {
         assertThat(jlinkArgs).noneMatch(arg -> arg.trim().isBlank());
     }
 
+    @DisabledOnOs(OS.WINDOWS)
     @Test
     void single_quotes_shell_command_unix() throws Exception {
-        Assumptions.assumeFalse(System.getProperty("os.name").startsWith("Windows"));
-
         // when
         List<String> jlinkArgs = mojo.createJlinkArgs(List.of("foo", "bar"), List.of("mvn", "jlink"));
         Commandline cmdLine = JLinkExecutor.createJLinkCommandLine(new File("/path/to/jlink"), jlinkArgs);
@@ -64,10 +66,9 @@ public class JLinkMojoTest {
                         "/bin/sh -c '/path/to/jlink \"--strip-debug\" \"--module-path\" \"foo:bar\" \"--add-modules\" \"mvn,jlink\"'");
     }
 
+    @EnabledOnOs(OS.WINDOWS)
     @Test
     void single_quotes_shell_command_windows() throws Exception {
-        Assumptions.assumeTrue(System.getProperty("os.name").startsWith("Windows"));
-
         // when
         List<String> jlinkArgs = mojo.createJlinkArgs(List.of("foo", "bar"), List.of("mvn", "jlink"));
         Commandline cmdLine = JLinkExecutor.createJLinkCommandLine(new File("/path/to/jlink"), jlinkArgs);

--- a/src/test/java/org/apache/maven/plugins/jlink/JLinkMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jlink/JLinkMojoTest.java
@@ -76,6 +76,6 @@ public class JLinkMojoTest {
         assertThat(cmdLine.toString()).startsWith("cmd.exe ");
         assertThat(cmdLine.toString())
                 .contains(
-                        "\\path\\to\\jlink \"-strip-debug\" \"module-path\" \"foo;bar\" \"-add-modules\" \"mvn,jlink");
+                        "\\path\\to\\jlink \"--strip-debug\" \"--module-path\" \"foo;bar\" \"--add-modules\" \"mvn,jlink");
     }
 }

--- a/src/test/java/org/apache/maven/plugins/jlink/JLinkMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jlink/JLinkMojoTest.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Field;
 import java.util.List;
 
 import org.apache.maven.shared.utils.cli.Commandline;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;


### PR DESCRIPTION
This likely doesn't actually fix the plugin on Windows, but does let tests pass so unrelated changes are not blocked. It also adds tests that show how the plugin operates on Windows so future PRs can build on that. 