### PR TITLE
Reduce injection

### DIFF
--- a/src/main/java/org/apache/maven/plugins/jlink/JLinkMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jlink/JLinkMojo.java
@@ -38,7 +38,6 @@ package org.apache.maven.plugins.jlink;
  */
 
 import javax.inject.Inject;
-import javax.inject.Named;
 
 import java.io.File;
 import java.io.IOException;
@@ -381,17 +380,15 @@ public class JLinkMojo extends AbstractJLinkMojo {
     /**
      * The JAR archiver needed for archiving the environments.
      */
-    private final ZipArchiver zipArchiver;
+    private final ZipArchiver zipArchiver = new ZipArchiver();
 
     @Inject
     public JLinkMojo(
             MavenProjectHelper projectHelper,
             ToolchainManager toolchainManager,
-            @Named("zip") ZipArchiver zipArchiver,
             MavenResourcesFiltering mavenResourcesFiltering,
             LocationManager locationManager) {
         super(toolchainManager);
-        this.zipArchiver = zipArchiver;
         this.mavenResourcesFiltering = mavenResourcesFiltering;
         this.projectHelper = projectHelper;
         this.locationManager = locationManager;

--- a/src/test/java/org/apache/maven/plugins/jlink/JLinkMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jlink/JLinkMojoTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class JLinkMojoTest {
 
-    private JLinkMojo mojo = new JLinkMojo(null, null, null, null, null);
+    private JLinkMojo mojo = new JLinkMojo(null, null, null, null);
 
     @BeforeEach
     public void setUp() throws NoSuchFieldException, IllegalAccessException {

--- a/src/test/java/org/apache/maven/plugins/jlink/MultipleLauncherTest.java
+++ b/src/test/java/org/apache/maven/plugins/jlink/MultipleLauncherTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class MultipleLauncherTest {
 
-    private JLinkMojo mojo = new JLinkMojo(null, null, null, null, null);
+    private JLinkMojo mojo = new JLinkMojo(null, null, null, null);
 
     @Test
     void testSingleLauncher() throws Exception {


### PR DESCRIPTION
I've started to wonder if anything is gained by injecting everything or if this is just another symptom of the AbstractFactoryProviderFactoryProvider antipattern Java is notorious for. In the case of ZipArchiver there's exactly one implementation which is an empty class that extends AbstractZipArchiver. That truly is needless abstraction and cargo cult thinking that every class needs an abstract superclass, though fixing that would have to be done in Plexus. 