### PR TITLE
Skip POM dependencies when assembling jlink classpath

### DIFF
--- a/src/main/java/org/apache/maven/plugins/jlink/JLinkMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jlink/JLinkMojo.java
@@ -464,12 +464,16 @@ public class JLinkMojo extends AbstractJLinkMojo {
         }
     }
 
-    private List<File> getCompileClasspathElements(MavenProject project) {
+    List<File> getCompileClasspathElements(MavenProject project) {
         List<File> list = new ArrayList<>(project.getArtifacts().size() + 1);
 
         for (Artifact a : project.getArtifacts()) {
-            getLog().debug("Artifact: " + a.getGroupId() + ":" + a.getArtifactId() + ":" + a.getVersion());
-            list.add(a.getFile());
+            boolean skip = "pom".equals(a.getType());
+            getLog().debug("Adding artifact: " + a.getGroupId() + ":" + a.getArtifactId() + ":" + a.getVersion()
+                    + (skip ? " (skipping)" : ""));
+            if (!skip) {
+                list.add(a.getFile());
+            }
         }
         return list;
     }

--- a/src/main/java/org/apache/maven/plugins/jlink/JLinkMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jlink/JLinkMojo.java
@@ -464,18 +464,35 @@ public class JLinkMojo extends AbstractJLinkMojo {
         }
     }
 
+    /**
+     * Gets the compile classpath elements while filtering out artifacts that should be skipped.
+     *
+     * @param project The Maven project
+     * @return List of files that should be included in the classpath
+     */
     List<File> getCompileClasspathElements(MavenProject project) {
         List<File> list = new ArrayList<>(project.getArtifacts().size() + 1);
 
-        for (Artifact a : project.getArtifacts()) {
-            boolean skip = "pom".equals(a.getType());
-            getLog().debug("Adding artifact: " + a.getGroupId() + ":" + a.getArtifactId() + ":" + a.getVersion()
-                    + (skip ? " (skipping)" : ""));
-            if (!skip) {
-                list.add(a.getFile());
+        for (Artifact artifact : project.getArtifacts()) {
+            boolean shouldSkip = shouldSkip(artifact);
+            getLog().debug("Adding artifact: " + artifact.getGroupId() + ":" + artifact.getArtifactId() + ":"
+                    + artifact.getVersion() + (shouldSkip ? " (skipping)" : ""));
+            if (!shouldSkip) {
+                list.add(artifact.getFile());
             }
         }
         return list;
+    }
+
+    /**
+     * Determines if an artifact should be skipped based on its properties.
+     * Currently, skips POM type artifacts, but can be extended for other cases.
+     *
+     * @param artifact The artifact to check
+     * @return true if the artifact should be skipped, false otherwise
+     */
+    private boolean shouldSkip(Artifact artifact) {
+        return "pom".equals(artifact.getType());
     }
 
     private Map<String, File> getModulePathElements() throws MojoFailureException {

--- a/src/test/java/org/apache/maven/plugins/jlink/JLinkMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jlink/JLinkMojoTest.java
@@ -21,15 +21,20 @@ package org.apache.maven.plugins.jlink;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.Set;
 
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.utils.cli.Commandline;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 public class JLinkMojoTest {
 
@@ -76,5 +81,25 @@ public class JLinkMojoTest {
         assertThat(cmdLine.toString())
                 .contains(
                         "\\path\\to\\jlink \"--strip-debug\" \"--module-path\" \"foo;bar\" \"--add-modules\" \"mvn,jlink");
+    }
+
+    @Test
+    void getCompileClasspathElements() throws Exception {
+        // Given
+        MavenProject project = Mockito.mock(MavenProject.class);
+
+        Artifact pomArtifact = Mockito.mock(Artifact.class);
+        when(pomArtifact.getType()).thenReturn("pom");
+
+        Artifact jarArtifact = Mockito.mock(Artifact.class);
+        when(jarArtifact.getType()).thenReturn("jar");
+        when(jarArtifact.getFile()).thenReturn(new File("some.jar"));
+
+        when(project.getArtifacts()).thenReturn(Set.of(pomArtifact, jarArtifact));
+
+        List<File> classpathElements = mojo.getCompileClasspathElements(project);
+
+        // Then
+        assertThat(classpathElements).containsExactly(new File("some.jar"));
     }
 }


### PR DESCRIPTION
Tags @slachiewicz, @khmarbaise @bmarwell 


Fixes https://github.com/apache/maven-jlink-plugin/issues/586

