### PR TITLE
[#602] - Add support for JLink plugins

### DIFF
--- a/src/it/projects/cli-options/additional-args/invoker.properties
+++ b/src/it/projects/cli-options/additional-args/invoker.properties
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+invoker.goals=clean package

--- a/src/it/projects/cli-options/additional-args/pom.xml
+++ b/src/it/projects/cli-options/additional-args/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
+>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-jlink-plugin-cli-options-additional-args</artifactId>
+    <version>99.0</version>
+    <packaging>jlink</packaging>
+    <name>Maven</name>
+    <url>http://maven.apache.org</url>
+    <description>Test JLink CLI Options additional args.</description>
+    <properties>
+        <maven.compiler.source>1.9</maven.compiler.source>
+        <maven.compiler.target>1.9</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>localhost</groupId>
+            <artifactId>first-jar-module-info</artifactId>
+            <version>99.0</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <source>1.9</source>
+                    <target>1.9</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jlink-plugin</artifactId>
+                <version>@project.version@</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <additionalArgs>
+                        <!-- using undocumented plugin to test; replace, if no longer available -->
+                        <additionalArg>--strip-native-commands</additionalArg>
+                    </additionalArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/projects/cli-options/additional-args/src/main/configs/config.test
+++ b/src/it/projects/cli-options/additional-args/src/main/configs/config.test
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+Test configuration file which should be located in config/config.test in
+resulting jmod file.

--- a/src/it/projects/cli-options/additional-args/verify.groovy
+++ b/src/it/projects/cli-options/additional-args/verify.groovy
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+import java.util.*;
+import java.util.jar.*;
+import org.codehaus.plexus.util.*;
+
+boolean result = true;
+
+try {
+    File target = new File(basedir, "target");
+    if (!target.exists() || !target.isDirectory()) {
+        System.err.println("target file is missing or not a directory.");
+        return false;
+    }
+    File artifact = new File(target, "maven-jlink-plugin-cli-options-additional-args-99.0.zip");
+    if (!artifact.exists() || artifact.isDirectory()) {
+        System.err.println("maven-jlink-plugin-cli-options-additional-args-99.0.zip file is missing or is a directory.");
+        return false;
+    }
+
+}
+catch (Throwable e) {
+    e.printStackTrace();
+    result = false;
+}
+
+return result;

--- a/src/it/projects/cli-options/generate-cds-archive/invoker.properties
+++ b/src/it/projects/cli-options/generate-cds-archive/invoker.properties
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+invoker.goals=clean package

--- a/src/it/projects/cli-options/generate-cds-archive/pom.xml
+++ b/src/it/projects/cli-options/generate-cds-archive/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
+>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-jlink-plugin-cli-options-generate-cds-archive</artifactId>
+    <version>99.0</version>
+    <packaging>jlink</packaging>
+    <name>Maven</name>
+    <url>http://maven.apache.org</url>
+    <description>Test JLink CLI Options --generate-cds-archive.</description>
+    <properties>
+        <maven.compiler.source>1.9</maven.compiler.source>
+        <maven.compiler.target>1.9</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>localhost</groupId>
+            <artifactId>first-jar-module-info</artifactId>
+            <version>99.0</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <source>1.9</source>
+                    <target>1.9</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jlink-plugin</artifactId>
+                <version>@project.version@</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <generateCdsArchive>true</generateCdsArchive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/projects/cli-options/generate-cds-archive/src/main/configs/config.test
+++ b/src/it/projects/cli-options/generate-cds-archive/src/main/configs/config.test
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+Test configuration file which should be located in config/config.test in
+resulting jmod file.

--- a/src/it/projects/cli-options/generate-cds-archive/verify.groovy
+++ b/src/it/projects/cli-options/generate-cds-archive/verify.groovy
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+import java.util.*;
+import java.util.jar.*;
+import org.codehaus.plexus.util.*;
+
+boolean result = true;
+
+try {
+    File target = new File(basedir, "target");
+    if (!target.exists() || !target.isDirectory()) {
+        System.err.println("target file is missing or not a directory.");
+        return false;
+    }
+    File artifact = new File(target, "maven-jlink-plugin-cli-options-generate-cds-archive-99.0.zip");
+    if (!artifact.exists() || artifact.isDirectory()) {
+        System.err.println("maven-jlink-plugin-cli-options-generate-cds-archive-99.0.zip file is missing or is a directory.");
+        return false;
+    }
+
+}
+catch (Throwable e) {
+    e.printStackTrace();
+    result = false;
+}
+
+return result;

--- a/src/it/projects/cli-options/order-resources/invoker.properties
+++ b/src/it/projects/cli-options/order-resources/invoker.properties
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+invoker.goals=clean package

--- a/src/it/projects/cli-options/order-resources/pom.xml
+++ b/src/it/projects/cli-options/order-resources/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
+>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-jlink-plugin-cli-options-order-resources</artifactId>
+    <version>99.0</version>
+    <packaging>jlink</packaging>
+    <name>Maven</name>
+    <url>http://maven.apache.org</url>
+    <description>Test JLink CLI Options --order-resources.</description>
+    <properties>
+        <maven.compiler.source>1.9</maven.compiler.source>
+        <maven.compiler.target>1.9</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>localhost</groupId>
+            <artifactId>first-jar-module-info</artifactId>
+            <version>99.0</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <source>1.9</source>
+                    <target>1.9</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jlink-plugin</artifactId>
+                <version>@project.version@</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <orderResources>
+                        <orderResource>module-info.class</orderResource>
+                    </orderResources>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/projects/cli-options/order-resources/src/main/configs/config.test
+++ b/src/it/projects/cli-options/order-resources/src/main/configs/config.test
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+Test configuration file which should be located in config/config.test in
+resulting jmod file.

--- a/src/it/projects/cli-options/order-resources/src/main/java/module-info.java
+++ b/src/it/projects/cli-options/order-resources/src/main/java/module-info.java
@@ -1,0 +1,21 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+ */
+module test {
+
+}

--- a/src/it/projects/cli-options/order-resources/verify.groovy
+++ b/src/it/projects/cli-options/order-resources/verify.groovy
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+import java.util.*;
+import java.util.jar.*;
+import org.codehaus.plexus.util.*;
+
+boolean result = true;
+
+try {
+    File target = new File(basedir, "target");
+    if (!target.exists() || !target.isDirectory()) {
+        System.err.println("target file is missing or not a directory.");
+        return false;
+    }
+    File artifact = new File(target, "maven-jlink-plugin-cli-options-order-resources-99.0.zip");
+    if (!artifact.exists() || artifact.isDirectory()) {
+        System.err.println("maven-jlink-plugin-cli-options-order-resources-99.0.zip file is missing or is a directory.");
+        return false;
+    }
+
+}
+catch (Throwable e) {
+    e.printStackTrace();
+    result = false;
+}
+
+return result;

--- a/src/main/java/org/apache/maven/plugins/jlink/JLinkMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jlink/JLinkMojo.java
@@ -383,6 +383,12 @@ public class JLinkMojo extends AbstractJLinkMojo {
     private List<Resource> additionalResources;
 
     /**
+     * These arguments are additionally passed to the jlink command line.
+     */
+    @Parameter
+    private List<String> additionalArgs;
+
+    /**
      * Convenience interface for plugins to add or replace artifacts and resources on projects.
      */
     private final MavenProjectHelper projectHelper;
@@ -763,6 +769,10 @@ public class JLinkMojo extends AbstractJLinkMojo {
 
         if (verbose) {
             jlinkArgs.add("--verbose");
+        }
+
+        if (additionalArgs != null && !additionalArgs.isEmpty()) {
+            jlinkArgs.addAll(additionalArgs);
         }
 
         // NOTE: suggestProviders is a terminal JlinkTask, so must be at the end!

--- a/src/main/java/org/apache/maven/plugins/jlink/JLinkMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jlink/JLinkMojo.java
@@ -330,6 +330,13 @@ public class JLinkMojo extends AbstractJLinkMojo {
     private boolean generateCdsArchive;
 
     /**
+     * This will order the specified paths in priority order.
+     * The JLink command line equivalent is: <code>--order-resources &lt;path&gt;[,&lt;path&gt;...]</code>
+     */
+    @Parameter
+    private List<String> orderResources;
+
+    /**
      * This will turn on verbose mode. The jlink command line equivalent is: <code>--verbose</code>
      */
     @Parameter(defaultValue = "false")
@@ -736,6 +743,11 @@ public class JLinkMojo extends AbstractJLinkMojo {
 
         if (generateCdsArchive) {
             jlinkArgs.add("--generate-cds-archive");
+        }
+
+        if (orderResources != null && !orderResources.isEmpty()) {
+            String sb = String.join(",", orderResources);
+            jlinkArgs.add("--order-resources=" + sb);
         }
 
         if (pluginModulePath != null) {

--- a/src/main/java/org/apache/maven/plugins/jlink/JLinkMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jlink/JLinkMojo.java
@@ -323,6 +323,13 @@ public class JLinkMojo extends AbstractJLinkMojo {
     private List<String> includeLocales;
 
     /**
+     * This will generate a CDS archive if the runtime image supports it.
+     * The JLink command line equivalent is: <code>--generate-cds-archive</code>
+     */
+    @Parameter(defaultValue = "false")
+    private boolean generateCdsArchive;
+
+    /**
      * This will turn on verbose mode. The jlink command line equivalent is: <code>--verbose</code>
      */
     @Parameter(defaultValue = "false")
@@ -725,6 +732,10 @@ public class JLinkMojo extends AbstractJLinkMojo {
             jlinkArgs.add("--include-locales");
             String sb = String.join(",", includeLocales);
             jlinkArgs.add(sb);
+        }
+
+        if (generateCdsArchive) {
+            jlinkArgs.add("--generate-cds-archive");
         }
 
         if (pluginModulePath != null) {


### PR DESCRIPTION
Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [GitHub issue](https://github.com/apache/maven-jlink-plugin/issues) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a GitHub issue.  Your pull request should address just this issue, without
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[#<num>] - Fixes bug in ApproximateQuantiles`,
       where you replace `#<num>` with the appropriate GitHub issue. Best practice
       is to use the GitHub issue title in the pull request title and in the first line of the
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

## Description

This PR add support for the JLink options `--generate-cds-archive` and `--order-resources`.
Additionally, it adds the ability to supply additional args to JLink to support undocumented plugins. See #602 for a list of those.

