### PR TITLE
Update to mockito 5.23.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>4.11.0</version>
+      <version>5.23.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Mocktio 5.x requires Java 11, what is needed anyway by the jlink plugin
