### PR TITLE
Use version properties in TI

### DIFF
--- a/src/it/projects/MJLINK-26/pom.xml
+++ b/src/it/projects/MJLINK-26/pom.xml
@@ -39,7 +39,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>@version.maven-compiler-plugin@</version>
         <configuration>
           <source>1.9</source>
           <target>1.9</target>

--- a/src/it/projects/MJLINK-3_improveVerboseOutput/pom.xml
+++ b/src/it/projects/MJLINK-3_improveVerboseOutput/pom.xml
@@ -62,7 +62,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
+          <version>@version.maven-compiler-plugin@</version>
           <configuration>
             <source>${maven.compiler.source}</source>
             <target>${maven.compiler.target}</target>

--- a/src/it/projects/MJLINK-40_includeLocales/pom.xml
+++ b/src/it/projects/MJLINK-40_includeLocales/pom.xml
@@ -68,7 +68,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
+          <version>@version.maven-compiler-plugin@</version>
           <configuration>
             <source>${maven.compiler.source}</source>
             <target>${maven.compiler.target}</target>

--- a/src/it/projects/MJLINK-41_addoptions-11/pom.xml
+++ b/src/it/projects/MJLINK-41_addoptions-11/pom.xml
@@ -45,7 +45,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>@version.maven-compiler-plugin@</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/it/projects/MJLINK-52_classifiers/pom.xml
+++ b/src/it/projects/MJLINK-52_classifiers/pom.xml
@@ -38,7 +38,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>@version.maven-compiler-plugin@</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/it/projects/MJLINK-52_classifiers_duplicate_classifier/pom.xml
+++ b/src/it/projects/MJLINK-52_classifiers_duplicate_classifier/pom.xml
@@ -38,7 +38,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>@version.maven-compiler-plugin@</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/it/projects/MJLINK-52_classifiers_duplicate_default/pom.xml
+++ b/src/it/projects/MJLINK-52_classifiers_duplicate_default/pom.xml
@@ -38,7 +38,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>@version.maven-compiler-plugin@</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/it/projects/MJLINK-52_classifiers_jarproject/pom.xml
+++ b/src/it/projects/MJLINK-52_classifiers_jarproject/pom.xml
@@ -38,7 +38,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>@version.maven-compiler-plugin@</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/it/projects/MJLINK-6_allowSetJmodPath/pom.xml
+++ b/src/it/projects/MJLINK-6_allowSetJmodPath/pom.xml
@@ -39,7 +39,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>@version.maven-compiler-plugin@</version>
         <configuration>
           <source>1.9</source>
           <target>1.9</target>

--- a/src/it/projects/MJLINK-77_compress-parameters/pom.xml
+++ b/src/it/projects/MJLINK-77_compress-parameters/pom.xml
@@ -38,7 +38,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.12.0</version>
+        <version>@version.maven-compiler-plugin@</version>
         <configuration>
           <release>21</release>
         </configuration>

--- a/src/it/projects/MJLINK-9_reactor/pom.xml
+++ b/src/it/projects/MJLINK-9_reactor/pom.xml
@@ -48,7 +48,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.1</version>
+          <version>@version.maven-compiler-plugin@</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/src/it/projects/attach_skip/pom.xml
+++ b/src/it/projects/attach_skip/pom.xml
@@ -48,7 +48,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>@version.maven-compiler-plugin@</version>
       </plugin>
       
       <plugin>

--- a/src/it/projects/cli-options/add-options/pom.xml
+++ b/src/it/projects/cli-options/add-options/pom.xml
@@ -45,7 +45,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>@version.maven-compiler-plugin@</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/it/projects/cli-options/bind-services/pom.xml
+++ b/src/it/projects/cli-options/bind-services/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>@version.maven-compiler-plugin@</version>
         <configuration>
           <source>1.9</source>
           <target>1.9</target>

--- a/src/it/projects/cli-options/compress-0/pom.xml
+++ b/src/it/projects/cli-options/compress-0/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>@version.maven-compiler-plugin@</version>
         <configuration>
           <source>1.9</source>
           <target>1.9</target>

--- a/src/it/projects/cli-options/compress-1/pom.xml
+++ b/src/it/projects/cli-options/compress-1/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>@version.maven-compiler-plugin@</version>
         <configuration>
           <source>1.9</source>
           <target>1.9</target>

--- a/src/it/projects/cli-options/compress-2/pom.xml
+++ b/src/it/projects/cli-options/compress-2/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>@version.maven-compiler-plugin@</version>
         <configuration>
           <source>1.9</source>
           <target>1.9</target>

--- a/src/it/projects/cli-options/disable-plugin/pom.xml
+++ b/src/it/projects/cli-options/disable-plugin/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>@version.maven-compiler-plugin@</version>
         <configuration>
           <source>1.9</source>
           <target>1.9</target>

--- a/src/it/projects/cli-options/endian-big/pom.xml
+++ b/src/it/projects/cli-options/endian-big/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>@version.maven-compiler-plugin@</version>
         <configuration>
           <source>1.9</source>
           <target>1.9</target>

--- a/src/it/projects/cli-options/endian/pom.xml
+++ b/src/it/projects/cli-options/endian/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>@version.maven-compiler-plugin@</version>
         <configuration>
           <source>1.9</source>
           <target>1.9</target>

--- a/src/it/projects/cli-options/ignore-signing-information/pom.xml
+++ b/src/it/projects/cli-options/ignore-signing-information/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>@version.maven-compiler-plugin@</version>
         <configuration>
           <source>1.9</source>
           <target>1.9</target>

--- a/src/it/projects/cli-options/no-header-files/pom.xml
+++ b/src/it/projects/cli-options/no-header-files/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>@version.maven-compiler-plugin@</version>
         <configuration>
           <source>1.9</source>
           <target>1.9</target>

--- a/src/it/projects/cli-options/no-man-pages/pom.xml
+++ b/src/it/projects/cli-options/no-man-pages/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>@version.maven-compiler-plugin@</version>
         <configuration>
           <source>1.9</source>
           <target>1.9</target>

--- a/src/it/projects/cli-options/strip-debug/pom.xml
+++ b/src/it/projects/cli-options/strip-debug/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>@version.maven-compiler-plugin@</version>
         <configuration>
           <source>1.9</source>
           <target>1.9</target>

--- a/src/it/projects/cli-options/suggest-providers/pom.xml
+++ b/src/it/projects/cli-options/suggest-providers/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>@version.maven-compiler-plugin@</version>
         <configuration>
           <source>1.9</source>
           <target>1.9</target>

--- a/src/it/projects/setup-jar-module-info/pom.xml
+++ b/src/it/projects/setup-jar-module-info/pom.xml
@@ -41,7 +41,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
+          <version>@version.maven-compiler-plugin@</version>
           <configuration>
             <source>1.9</source>
             <target>1.9</target>

--- a/src/it/projects/setup-jar/pom.xml
+++ b/src/it/projects/setup-jar/pom.xml
@@ -41,7 +41,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
+          <version>@version.maven-compiler-plugin@</version>
           <configuration>
             <source>1.9</source>
             <target>1.9</target>


### PR DESCRIPTION
Locally "cli-options\endian-big\pom.xml" fails as it uses an option which is invalid on Windows. (according to AI) It needs to be little on Windows or skipped at all (like in IT cli-options\endian), so jlink chooses what fits for the machine.